### PR TITLE
Fixes issue #37

### DIFF
--- a/env.py
+++ b/env.py
@@ -95,6 +95,9 @@ class EnsimeEnvironment(object):
     # that don't exist.
     self.completion_ignore_prefix = None
 
+    # typechecked files
+    self.typechecked_files = set()
+
     # debugger stuff (mutable)
     # didn't prefix it with "debugger_", because there are no name clashes yet
     self.profile_being_launched = None


### PR DESCRIPTION
Instead of triggering typechecking during on_load, it does it
on_activation. Now, we don't want to do it on each activation
(which is triggered each time we switch to the tab) -- so we
keep a set of typechecked files in the env.

One thing I don't understand is why is ensime typechecking all
the previously-opened files instead of only the opened ones...
