### PR TITLE
Update Ensime (Windows).sublime-settings

### DIFF
--- a/Ensime (Windows).sublime-settings
+++ b/Ensime (Windows).sublime-settings
@@ -1,4 +1,4 @@
 {
   // build settings
-  "sbt_binary": "sbt"
+  "sbt_binary": "sbt.bat"
 }


### PR DESCRIPTION
On windows environment, even though there is sbt.bat in PATH it's need to add file extension.
